### PR TITLE
Adding support for HTTP and TCP pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported protocols are:
 Syntax:
 
 ```
-ping [protocol] <target> - Ping <target> (either DNS nane, IP address, or URI)
+ping [protocol] <target> - Ping <target> (either DNS name, IP address, or URI)
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -26,18 +26,28 @@ none
 Examples:
 
 ```
-ping google.com - Ping google.com
+ping google.com - Ping google.com via normal ICMP
+ping icmp google.com - Ping google.com via normal ICMP (same as above)
+ping http://www.google.com - Ping google.com via HTTP
+ping tcp://ldap.server:389 - Ping a TCP service running on ldap.server on port 389
+ping tcp app.server:8080 - Ping a TCP service running on app.server on port 8080
 ```
+
+Supported protocols are:
+
+* `http` - Ping a web service. It is usually simplest to just specify the URI like you would in a web browser.
+* `icmp` - The default if none is specified. This is your standard ping.
+* `tcp` - Verify that a TCP service is listening and responding. Note that this doesn't guarantee that the service is not misbehaving, just that it responds on the proper port.
 
 Syntax:
 
 ```
-ping <target> - Ping <target> (either DNS or IP address)
+ping [protocol] <target> - Ping <target> (either DNS nane, IP address, or URI)
 ```
 
 ## Note
 
-This plugin uses the net-ping library, and the "Net::Ping::External" check,
+This plugin uses the net-ping library, and the ICMP ping uses the "Net::Ping::External" check,
 so it will use the "ping" equivalent on whatever host it's running on.
 
 ## License

--- a/lib/lita-netping.rb
+++ b/lib/lita-netping.rb
@@ -7,3 +7,4 @@ Lita.load_locales Dir[File.expand_path(
 require 'lita/handlers/netping'
 
 require 'net/ping'
+require 'uri'

--- a/lib/lita/handlers/netping.rb
+++ b/lib/lita/handlers/netping.rb
@@ -2,7 +2,7 @@ module Lita
   module Handlers
     class Netping < Handler
       route(
-        /^ping\s(?<target>.+)/,
+        /^ping(\s+(?<proto>\S+))?\s(?<target>\S+)/,
         :ping,
         command: true,
         help: {
@@ -11,9 +11,18 @@ module Lita
       )
 
       def ping(response)
+        proto  = response.match_data['proto'] || 'icmp'
         target = response.match_data['target']
 
-        response.reply(format(target, ping_target(target)))
+        # Update the protocol based on the target
+        proto = URI(target).scheme if target.match /^(\S+):\/\/\S+/
+
+        unless ['http', 'icmp', 'tcp'].include?(proto.downcase)
+          response.reply(t('ping.unsupported', proto: proto))
+          return false
+        end
+
+        response.reply(format(target, ping_target(proto.downcase, target)))
       end
 
       private
@@ -26,9 +35,32 @@ module Lita
         end
       end
 
-      def ping_target(host)
-        p = Net::Ping::External.new(host)
-        p.ping(host, 1, 1, 1)
+      def ping_target(proto, target)
+        # dissect the target to get the hostname and port
+        if target.match /^(\S+):\/\/\S+/
+          uri = URI(target)
+          host = uri.host
+          port = uri.port
+        elsif target.match /:[0-9]+$/
+          host, _, port = target.rpartition(':')
+        else
+          host = target
+          port = nil
+        end
+
+        case proto
+        when 'http'
+          # With HTTP, we can just pass the target
+          p = Net::Ping::HTTP.new(target)
+          p.ping
+        when 'icmp'
+          # The default
+          p = Net::Ping::External.new(host)
+          p.ping(host, 1, 1, 1)
+        when 'tcp'
+          p = port ? Net::Ping::TCP.new(host, port) : Net::Ping::TCP.new(host)
+          p.ping
+        end
       end
     end
 

--- a/lita-netping.gemspec
+++ b/lita-netping.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,8 +4,9 @@ en:
       netping:
         help:
           ping:
-            syntax: ping <target>
-            desc: Ping <target> (either DNS or IP address)
+            syntax: ping [protocol] <target>
+            desc: Ping [protocol] <target> (either DNS or IP address)
         ping:
           success: "%{host} responded to ping"
           fail: "%{host} did not respond to ping"
+          unsupported: "%{proto} is not a supported protocol"

--- a/spec/lita/handlers/netping_spec.rb
+++ b/spec/lita/handlers/netping_spec.rb
@@ -11,9 +11,29 @@ describe Lita::Handlers::Netping, lita_handler: true do
       expect(replies.last).to eq('example.com responded to ping')
     end
 
+    it 'returns a success if the target is pingable via HTTP' do
+      send_command('ping http example.com')
+      expect(replies.last).to eq('example.com responded to ping')
+    end
+
+    it 'returns a success if the target is pingable via TCP' do
+      send_command('ping tcp 127.0.0.1:6379')
+      expect(replies.last).to eq('127.0.0.1:6379 responded to ping')
+    end
+
+    it 'returns a success if the target is pingable via TCP as a URI' do
+      send_command('ping tcp://127.0.0.1:6379')
+      expect(replies.last).to eq('tcp://127.0.0.1:6379 responded to ping')
+    end
+
     it 'returns a failure if the target is not pingable' do
       send_command('ping unknownhost.local')
       expect(replies.last).to eq('unknownhost.local did not respond to ping')
+    end
+
+    it 'returns a failure if the protocol is not supported' do
+      send_command('ping xmpp://jabber.org')
+      expect(replies.last).to eq('xmpp is not a supported protocol')
     end
   end
 end


### PR DESCRIPTION
This includes a flexible syntax, allowing either passing a protocol explicitly or via a standard URI string. See the README update for more details on that. Best of all, existing behavior is preserved.

Several tests were added and all passed locally.